### PR TITLE
Idea - Configure ClientAccessTokenHandler

### DIFF
--- a/samples/TokenManagement2/Controllers/HomeController.cs
+++ b/samples/TokenManagement2/Controllers/HomeController.cs
@@ -15,9 +15,12 @@ namespace AspNetCoreSecurity.Controllers
     {
         private readonly IHttpClientFactory _httpClientFactory;
 
-        public HomeController(IHttpClientFactory httpClientFactory)
+        private readonly TypedHttpClient _typedHttpClient;
+
+        public HomeController(IHttpClientFactory httpClientFactory, TypedHttpClient typedHttpClient)
         {
             _httpClientFactory = httpClientFactory;
+            _typedHttpClient = typedHttpClient;
         }
 
         [AllowAnonymous]
@@ -41,6 +44,16 @@ namespace AspNetCoreSecurity.Controllers
             return View();
         }
 
+        [AllowAnonymous]
+        public async Task<IActionResult> CallApi2()
+        {
+            var client = _httpClientFactory.CreateClient("m2m");
+
+            ViewBag.Json = await _typedHttpClient.ApiTest();
+
+            return View("CallApi");
+        }
+
         public async Task<IActionResult> CallApiManual()
         {
             var token = await HttpContext.GetUserAccessTokenAsync();
@@ -51,7 +64,7 @@ namespace AspNetCoreSecurity.Controllers
             var response = await client.GetStringAsync("https://demo.identityserver.io/api/test");
             ViewBag.Json = JArray.Parse(response).ToString();
 
-            return View();
+            return View("CallApi");
         }
     }
 }

--- a/samples/TokenManagement2/Controllers/HomeController.cs
+++ b/samples/TokenManagement2/Controllers/HomeController.cs
@@ -49,7 +49,8 @@ namespace AspNetCoreSecurity.Controllers
         {
             var client = _httpClientFactory.CreateClient("m2m");
 
-            ViewBag.Json = await _typedHttpClient.ApiTest();
+            var response = await _typedHttpClient.ApiTest();
+            ViewBag.Json = JArray.Parse(response).ToString();
 
             return View("CallApi");
         }

--- a/samples/TokenManagement2/Controllers/HomeController.cs
+++ b/samples/TokenManagement2/Controllers/HomeController.cs
@@ -47,8 +47,6 @@ namespace AspNetCoreSecurity.Controllers
         [AllowAnonymous]
         public async Task<IActionResult> CallApi2()
         {
-            var client = _httpClientFactory.CreateClient("m2m");
-
             var response = await _typedHttpClient.ApiTest();
             ViewBag.Json = JArray.Parse(response).ToString();
 

--- a/samples/TokenManagement2/Startup.cs
+++ b/samples/TokenManagement2/Startup.cs
@@ -10,28 +10,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using System;
 using System.IdentityModel.Tokens.Jwt;
-using System.Net.Http;
-using System.Threading.Tasks;
 using IdentityModel.Client;
 using Microsoft.AspNetCore.Http;
 
 namespace AspNetCoreSecurity
 {
-    public class TypedHttpClient
-    {
-        private readonly HttpClient _httpClient;
-
-        public TypedHttpClient(HttpClient httpClient)
-        {
-            _httpClient = httpClient;
-        }
-
-        public Task<string> ApiTest()
-        {
-            return _httpClient.GetStringAsync("api/test");
-        }
-    }
-
     public class Startup
     {
         public Startup()

--- a/samples/TokenManagement2/Startup.cs
+++ b/samples/TokenManagement2/Startup.cs
@@ -32,12 +32,7 @@ namespace AspNetCoreSecurity
                 {
                     client.BaseAddress = new Uri("https://demo.identityserver.io");
                 })
-                .AddHttpMessageHandler(provider =>
-                {
-                    var httpContextAccessor = provider.GetRequiredService<IHttpContextAccessor>();
-
-                    return new ClientAccessTokenHandler(httpContextAccessor, "m2m");
-                });
+                .AddClientAccessTokenClient("m2m");
 
             services.AddAccessTokenManagement(options =>
                 {

--- a/samples/TokenManagement2/TypedHttpClient.cs
+++ b/samples/TokenManagement2/TypedHttpClient.cs
@@ -1,0 +1,20 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace AspNetCoreSecurity
+{
+    public class TypedHttpClient
+    {
+        private readonly HttpClient _httpClient;
+
+        public TypedHttpClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public Task<string> ApiTest()
+        {
+            return _httpClient.GetStringAsync("api/test");
+        }
+    }
+}

--- a/src/AccessTokenManagement/ClientAccessTokenHandler.cs
+++ b/src/AccessTokenManagement/ClientAccessTokenHandler.cs
@@ -17,19 +17,23 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
 
+        private readonly string _clientName;
+
         /// <summary>
         /// ctor
         /// </summary>
         /// <param name="httpContextAccessor"></param>
-        public ClientAccessTokenHandler(IHttpContextAccessor httpContextAccessor)
+        /// <param name="clientName"></param>
+        public ClientAccessTokenHandler(IHttpContextAccessor httpContextAccessor, string clientName = null)
         {
             _httpContextAccessor = httpContextAccessor;
+            _clientName = clientName;
         }
 
         /// <inheritdoc/>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var token = await _httpContextAccessor.HttpContext.GetClientAccessTokenAsync();
+            var token = await _httpContextAccessor.HttpContext.GetClientAccessTokenAsync(_clientName);
 
             if (!string.IsNullOrEmpty(token))
             {

--- a/src/AccessTokenManagement/TokenManagementServiceCollectionExtensions.cs
+++ b/src/AccessTokenManagement/TokenManagementServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using IdentityModel.AspNetCore.AccessTokenManagement;
 using System;
 using System.Net.Http;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -79,6 +80,16 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return services.AddHttpClient(name)
                 .AddHttpMessageHandler<ClientAccessTokenHandler>();
+        }
+
+        public static IHttpClientBuilder AddClientAccessTokenClient(this IHttpClientBuilder httpClientBuilder, string clientName)
+        {
+            return httpClientBuilder.AddHttpMessageHandler(provider =>
+            {
+                var httpContextAccessor = provider.GetRequiredService<IHttpContextAccessor>();
+
+                return new ClientAccessTokenHandler(httpContextAccessor, clientName);
+            });
         }
     }
 }


### PR DESCRIPTION
Add ability to configure ClientAccessTokenHandler with a specific client name. Could possibly be useful for things like TypedClients?

Downside there does not seem like a nice way to automatically configure using OpenId Connect Service Discovery route.