### PR TITLE
Pass TokenClientOptions Parameters to RequestClientCredentialsTokenAsync

### DIFF
--- a/src/AccessTokenManagement/TokenEndpointService.cs
+++ b/src/AccessTokenManagement/TokenEndpointService.cs
@@ -84,7 +84,8 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
                 Address = tokenClientOptions.Address,
 
                 ClientId = tokenClientOptions.ClientId,
-                ClientSecret = tokenClientOptions.ClientSecret
+                ClientSecret = tokenClientOptions.ClientSecret,
+                Parameters = tokenClientOptions.Parameters
             });
         }
 

--- a/test/Tests/Infrastructure/NetworkHandler.cs
+++ b/test/Tests/Infrastructure/NetworkHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,9 +9,12 @@ namespace Tests.Infrastructure
     {
         public Uri Address { get; set; }
 
+        public HttpContent Content { get; set; }
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Address = request.RequestUri;
+            Content = request.Content;
 
             return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.NotFound));
         }


### PR DESCRIPTION
Allow passing custom parameters (Such as audience)