### PR TITLE
TryAddTransient<ITokenClientConfigurationService instead of AddTransient

### DIFF
--- a/src/AccessTokenManagement/TokenManagementServiceCollectionExtensions.cs
+++ b/src/AccessTokenManagement/TokenManagementServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using IdentityModel.AspNetCore.AccessTokenManagement;
 using System;
 using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -33,7 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
 #endif
 
             services.AddTransient<IAccessTokenManagementService, AccessTokenManagementService>();
-            services.AddTransient<ITokenClientConfigurationService, DefaultTokenClientConfigurationService>();
+            services.TryAddTransient<ITokenClientConfigurationService, DefaultTokenClientConfigurationService>();
             services.AddTransient<ITokenEndpointService, TokenEndpointService>();
 
             services.AddHttpClient(AccessTokenManagementDefaults.BackChannelHttpClientName);


### PR DESCRIPTION
Reason:
If use `TryAddTransient()` then position of 
`services.AddTransient<ITokenClientConfigurationService, MyOptionsTokenClientConfigurationService>();` 
is **not** important - registration of `MyOptionsTokenClientConfigurationService` implementation can happen before or after `services.AddAccessTokenManagement()`.

If use `AddTransient()`, then `services.AddTransient<ITokenClientConfigurationService, MyOptionsTokenClientConfigurationService>(); `
must be after  `services.AddAccessTokenManagement()`.