### PR TITLE
Only update Refresh Token if it isn't null

### DIFF
--- a/src/AccessTokenManagement/AuthenticationSessionUserTokenStore.cs
+++ b/src/AccessTokenManagement/AuthenticationSessionUserTokenStore.cs
@@ -86,7 +86,10 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
             }
 
             result.Properties.UpdateTokenValue(OpenIdConnectParameterNames.AccessToken, accessToken);
-            result.Properties.UpdateTokenValue(OpenIdConnectParameterNames.RefreshToken, refreshToken);
+            if (refreshToken != null)
+            {
+                result.Properties.UpdateTokenValue(OpenIdConnectParameterNames.RefreshToken, refreshToken);
+            }
 
             var newExpiresAt = DateTime.UtcNow + TimeSpan.FromSeconds(expiresIn);
             result.Properties.UpdateTokenValue("expires_at", newExpiresAt.ToString("o", CultureInfo.InvariantCulture));


### PR DESCRIPTION
This fixes an issue where Auth0 doesn't return a new Refresh Token when refreshing the Access Token. 

Currently it expects it to be set, and overwrites the existing token with null. This simply checks that the new token isn't null before setting it.

I've tested this and confirmed it fixes my issue.

This is for issue #90 