### PR TITLE
IUserTokenStore.StoreTokenAsync() replaced parameter `expiresIn` with `expiration`

### DIFF
--- a/src/AccessTokenManagement/AccessTokenManagementService.cs
+++ b/src/AccessTokenManagement/AccessTokenManagementService.cs
@@ -164,7 +164,9 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
 
             if (!response.IsError)
             {
-                await _userTokenStore.StoreTokenAsync(user, response.AccessToken, response.ExpiresIn, response.RefreshToken);
+                var expiration = DateTime.UtcNow + TimeSpan.FromSeconds(response.ExpiresIn);
+
+                await _userTokenStore.StoreTokenAsync(user, response.AccessToken, expiration, response.RefreshToken);
             }
             else
             {

--- a/src/AccessTokenManagement/AuthenticationSessionUserTokenStore.cs
+++ b/src/AccessTokenManagement/AuthenticationSessionUserTokenStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication;
@@ -76,7 +76,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         }
 
         /// <inheritdoc/>
-        public async Task StoreTokenAsync(ClaimsPrincipal user, string accessToken, int expiresIn, string refreshToken)
+        public async Task StoreTokenAsync(ClaimsPrincipal user, string accessToken, DateTimeOffset expiration, string refreshToken)
         {
             var result = await _contextAccessor.HttpContext.AuthenticateAsync();
 
@@ -91,8 +91,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
                 result.Properties.UpdateTokenValue(OpenIdConnectParameterNames.RefreshToken, refreshToken);
             }
 
-            var newExpiresAt = DateTime.UtcNow + TimeSpan.FromSeconds(expiresIn);
-            result.Properties.UpdateTokenValue("expires_at", newExpiresAt.ToString("o", CultureInfo.InvariantCulture));
+            result.Properties.UpdateTokenValue("expires_at", expiration.ToString("o", CultureInfo.InvariantCulture));
 
             await _contextAccessor.HttpContext.SignInAsync(result.Principal, result.Properties);
         }

--- a/src/AccessTokenManagement/IUserTokenStore.cs
+++ b/src/AccessTokenManagement/IUserTokenStore.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
@@ -16,10 +17,10 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         /// </summary>
         /// <param name="user">User the tokens belong to</param>
         /// <param name="accessToken">The access token</param>
-        /// <param name="expiresIn">The access token lifetime in seconds</param>
+        /// <param name="expiration">The access token expiration</param>
         /// <param name="refreshToken">The refresh token</param>
         /// <returns></returns>
-        Task StoreTokenAsync(ClaimsPrincipal user, string accessToken, int expiresIn, string refreshToken);
+        Task StoreTokenAsync(ClaimsPrincipal user, string accessToken, DateTimeOffset expiration, string refreshToken);
 
         /// <summary>
         /// Retrieves tokens from store


### PR DESCRIPTION
This change basically avoids the need to convert `expiresIn` back to `expiration` in custom implementation of `IUserTokenStore`. Also the data type and parameter name now match with the property of data class `UserAccessToken.Expiration`. 

Background for this change:

In Blazor an existing access token and expiration has to be passed to the app manually in `_Host.cshtml` to initialize the `UserTokenStore` with initial values, otherwise the `AccessTokenManagementService` will report `No token data found in user token store.`.

To pass the expiration you would need to first convert `expires_at` to `expires_in` which is then converted back again to `expires_at` in `StoreTokenAsync()` to store the value in `UserAccessToken.Expiration`. 