### PR TITLE
Pass cancellation token to token retrieval process

### DIFF
--- a/src/AccessTokenManagement/ClientAccessTokenCache.cs
+++ b/src/AccessTokenManagement/ClientAccessTokenCache.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace IdentityModel.AspNetCore.AccessTokenManagement
@@ -32,11 +33,11 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         }
 
         /// <inheritdoc/>
-        public async Task<ClientAccessToken> GetAsync(string clientName)
+        public async Task<ClientAccessToken> GetAsync(string clientName, CancellationToken cancellationToken = default)
         {
             if (clientName is null) throw new ArgumentNullException(nameof(clientName));
             
-            var entry = await _cache.GetStringAsync(_options.Client.CacheKeyPrefix + clientName);
+            var entry = await _cache.GetStringAsync(_options.Client.CacheKeyPrefix + clientName, token: cancellationToken);
 
             if (entry != null)
             {
@@ -64,7 +65,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         }
 
         /// <inheritdoc/>
-        public async Task SetAsync(string clientName, string accessToken, int expiresIn)
+        public async Task SetAsync(string clientName, string accessToken, int expiresIn, CancellationToken cancellationToken = default)
         {
             if (clientName is null) throw new ArgumentNullException(nameof(clientName));
 
@@ -80,15 +81,15 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
             };
 
             _logger.LogDebug("Caching access token for client: {clientName}. Expiration: {expiration}", clientName, cacheExpiration);
-            await _cache.SetStringAsync(_options.Client.CacheKeyPrefix + clientName, data, entryOptions);
+            await _cache.SetStringAsync(_options.Client.CacheKeyPrefix + clientName, data, entryOptions, token: cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task DeleteAsync(string clientName)
+        public Task DeleteAsync(string clientName, CancellationToken cancellationToken = default)
         {
             if (clientName is null) throw new ArgumentNullException(nameof(clientName));
 
-            return _cache.RemoveAsync(_options.Client.CacheKeyPrefix + clientName);
+            return _cache.RemoveAsync(_options.Client.CacheKeyPrefix + clientName, cancellationToken);
         }
     }
 }

--- a/src/AccessTokenManagement/ClientAccessTokenHandler.cs
+++ b/src/AccessTokenManagement/ClientAccessTokenHandler.cs
@@ -30,7 +30,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         /// <inheritdoc/>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            await SetTokenAsync(request, forceRenewal: false);
+            await SetTokenAsync(request, forceRenewal: false, cancellationToken);
             var response = await base.SendAsync(request, cancellationToken);
 
             // retry if 401
@@ -38,7 +38,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
             {
                 response.Dispose();
 
-                await SetTokenAsync(request, forceRenewal: true);
+                await SetTokenAsync(request, forceRenewal: true, cancellationToken);
                 return await base.SendAsync(request, cancellationToken);
             }
 
@@ -50,10 +50,11 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         /// </summary>
         /// <param name="request"></param>
         /// <param name="forceRenewal"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        protected virtual async Task SetTokenAsync(HttpRequestMessage request, bool forceRenewal)
+        protected virtual async Task SetTokenAsync(HttpRequestMessage request, bool forceRenewal, CancellationToken cancellationToken)
         {
-            var token = await _accessTokenManagementService.GetClientAccessTokenAsync(_tokenClientName, forceRenewal);
+            var token = await _accessTokenManagementService.GetClientAccessTokenAsync(_tokenClientName, forceRenewal, cancellationToken);
 
             if (!string.IsNullOrWhiteSpace(token))
             {

--- a/src/AccessTokenManagement/IAccessTokenManagementService.cs
+++ b/src/AccessTokenManagement/IAccessTokenManagementService.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace IdentityModel.AspNetCore.AccessTokenManagement
 {
     /// <summary>
-    /// Abstraction for managing user and client accesss tokens
+    /// Abstraction for managing user and client access tokens
     /// </summary>
     public interface IAccessTokenManagementService
     {
@@ -15,27 +16,29 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         /// Returns the user access token. If the current token is expired, it will try to refresh it.
         /// </summary>
         /// <returns>An access token or null if refreshing did not work.</returns>
-        Task<string> GetUserAccessTokenAsync(ClaimsPrincipal user, bool forceRenewal = false);
+        Task<string> GetUserAccessTokenAsync(ClaimsPrincipal user, bool forceRenewal = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Revokes the current refresh token
         /// </summary>
         /// <returns></returns>
-        Task RevokeRefreshTokenAsync(ClaimsPrincipal user);
+        Task RevokeRefreshTokenAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns either a cached or a new access token for a given client configuration or the default client
         /// </summary>
         /// <param name="clientName">Name of the client configuration, or default is omitted.</param>
         /// <param name="forceRenewal">Ignores the cached token, and gets a new one.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation</param>
         /// <returns>The access token or null if the no token can be requested.</returns>
-        Task<string> GetClientAccessTokenAsync(string clientName = AccessTokenManagementDefaults.DefaultTokenClientName, bool forceRenewal = false);
+        Task<string> GetClientAccessTokenAsync(string clientName = AccessTokenManagementDefaults.DefaultTokenClientName, bool forceRenewal = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a client access token from the cache
         /// </summary>
         /// <param name="clientName">Name of the client configuration, or default is omitted.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel operation.</param>
         /// <returns>The access token or null if the no token can be requested.</returns>
-        Task DeleteClientAccessTokenAsync(string clientName = AccessTokenManagementDefaults.DefaultTokenClientName);
+        Task DeleteClientAccessTokenAsync(string clientName = AccessTokenManagementDefaults.DefaultTokenClientName, CancellationToken cancellationToken = default);
     }
 }

--- a/src/AccessTokenManagement/IClientAccessTokenCache.cs
+++ b/src/AccessTokenManagement/IClientAccessTokenCache.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace IdentityModel.AspNetCore.AccessTokenManagement
@@ -16,21 +17,24 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         /// <param name="clientName"></param>
         /// <param name="accessToken"></param>
         /// <param name="expiresIn"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task SetAsync(string clientName, string accessToken, int expiresIn);
-        
+        Task SetAsync(string clientName, string accessToken, int expiresIn, CancellationToken cancellationToken = default);
+
         /// <summary>
         /// Retrieves a client access token from the cache
         /// </summary>
         /// <param name="clientName"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<ClientAccessToken> GetAsync(string clientName);
+        Task<ClientAccessToken> GetAsync(string clientName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a client access token from the cache
         /// </summary>
         /// <param name="clientName"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task DeleteAsync(string clientName);
+        Task DeleteAsync(string clientName, CancellationToken cancellationToken = default);
     }
 }

--- a/src/AccessTokenManagement/ITokenEndpointService.cs
+++ b/src/AccessTokenManagement/ITokenEndpointService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using IdentityModel.Client;
 
@@ -15,21 +16,24 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         /// Refreshes a user access token.
         /// </summary>
         /// <param name="refreshToken"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TokenResponse> RefreshUserAccessTokenAsync(string refreshToken);
-        
+        Task<TokenResponse> RefreshUserAccessTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
+
         /// <summary>
         /// Requests a client access token.
         /// </summary>
         /// <param name="clientName"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TokenResponse> RequestClientAccessToken(string clientName = null);
-        
+        Task<TokenResponse> RequestClientAccessToken(string clientName = null, CancellationToken cancellationToken = default);
+
         /// <summary>
         /// Revokes a refresh token.
         /// </summary>
         /// <param name="refreshToken"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TokenRevocationResponse> RevokeRefreshTokenAsync(string refreshToken);
+        Task<TokenRevocationResponse> RevokeRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
     }
 }

--- a/src/AccessTokenManagement/TokenEndpointService.cs
+++ b/src/AccessTokenManagement/TokenEndpointService.cs
@@ -9,6 +9,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace IdentityModel.AspNetCore.AccessTokenManagement
@@ -35,30 +36,32 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         }
 
         /// <inheritdoc/>
-        public async Task<TokenResponse> RequestClientAccessToken(string clientName = AccessTokenManagementDefaults.DefaultTokenClientName)
+        public async Task<TokenResponse> RequestClientAccessToken(
+            string clientName = AccessTokenManagementDefaults.DefaultTokenClientName, 
+            CancellationToken cancellationToken = default)
         {
             var requestDetails = await _configService.GetClientCredentialsRequestAsync(clientName);
 
-            return await _httpClient.RequestClientCredentialsTokenAsync(requestDetails);
+            return await _httpClient.RequestClientCredentialsTokenAsync(requestDetails, cancellationToken: cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<TokenResponse> RefreshUserAccessTokenAsync(string refreshToken)
+        public async Task<TokenResponse> RefreshUserAccessTokenAsync(string refreshToken, CancellationToken cancellationToken = default)
         {
             var requestDetails = await _configService.GetRefreshTokenRequestAsync();
             requestDetails.RefreshToken = refreshToken;
 
-            return await _httpClient.RequestRefreshTokenAsync(requestDetails);
+            return await _httpClient.RequestRefreshTokenAsync(requestDetails, cancellationToken: cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<TokenRevocationResponse> RevokeRefreshTokenAsync(string refreshToken)
+        public async Task<TokenRevocationResponse> RevokeRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default)
         {
             var requestDetails = await _configService.GetTokenRevocationRequestAsync();
             requestDetails.Token = refreshToken;
             requestDetails.TokenTypeHint = OidcConstants.TokenTypes.RefreshToken;
 
-            return await _httpClient.RevokeTokenAsync(requestDetails);
+            return await _httpClient.RevokeTokenAsync(requestDetails, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/AccessTokenManagement/TokenManagementHttpContextExtensions.cs
+++ b/src/AccessTokenManagement/TokenManagementHttpContextExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Threading;
 using IdentityModel.AspNetCore.AccessTokenManagement;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,12 +19,13 @@ namespace Microsoft.AspNetCore.Authentication
         /// </summary>
         /// <param name="context"></param>
         /// <param name="forceRenewal">If set to true, the cached user token is ignored, and a new one gets requested. Default to false.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel operation.</param>
         /// <returns></returns>
-        public static async Task<string> GetUserAccessTokenAsync(this HttpContext context, bool forceRenewal = false)
+        public static async Task<string> GetUserAccessTokenAsync(this HttpContext context, bool forceRenewal = false, CancellationToken cancellationToken = default)
         {
             var service = context.RequestServices.GetRequiredService<IAccessTokenManagementService>();
 
-            return await service.GetUserAccessTokenAsync(context.User, forceRenewal);
+            return await service.GetUserAccessTokenAsync(context.User, forceRenewal, cancellationToken);
         }
 
         /// <summary>
@@ -32,25 +34,31 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="context"></param>
         /// <param name="clientName">Name of the client configuration (or null to use the standard client).</param>
         /// <param name="forceRenewal">If set to true, the cached access token is ignored, and a new one gets requested. Default to false.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel operation.</param>
         /// <returns></returns>
-        public static async Task<string> GetClientAccessTokenAsync(this HttpContext context, string clientName = AccessTokenManagementDefaults.DefaultTokenClientName, bool forceRenewal = false)
+        public static async Task<string> GetClientAccessTokenAsync(
+            this HttpContext context, 
+            string clientName = AccessTokenManagementDefaults.DefaultTokenClientName, 
+            bool forceRenewal = false,
+            CancellationToken cancellationToken = default)
         {
             var service = context.RequestServices.GetRequiredService<IAccessTokenManagementService>();
 
-            return await service.GetClientAccessTokenAsync(clientName, forceRenewal);
+            return await service.GetClientAccessTokenAsync(clientName, forceRenewal, cancellationToken);
         }
 
         /// <summary>
         /// Revokes the current user refresh token
         /// </summary>
         /// <param name="context"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task RevokeUserRefreshTokenAsync(this HttpContext context)
+        public static async Task RevokeUserRefreshTokenAsync(this HttpContext context, CancellationToken cancellationToken = default)
         {
             var service = context.RequestServices.GetRequiredService<IAccessTokenManagementService>();
             var store = context.RequestServices.GetRequiredService<IUserTokenStore>();
 
-            await service.RevokeRefreshTokenAsync(context.User);
+            await service.RevokeRefreshTokenAsync(context.User, cancellationToken);
             await store.ClearTokenAsync(context.User);
         }
     }


### PR DESCRIPTION
This PR will propagate the original Cancellation token from the incoming request to the process of retrieving a new token.

Fixes #156 