### PR TITLE
Pass parameters along to all methods

### DIFF
--- a/src/AccessTokenManagement/TokenManagementHttpContextExtensions.cs
+++ b/src/AccessTokenManagement/TokenManagementHttpContextExtensions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Authentication
             var store = httpContext.RequestServices.GetRequiredService<IUserTokenStore>();
 
             await service.RevokeRefreshTokenAsync(httpContext.User, parameters, cancellationToken);
-            await store.ClearTokenAsync(httpContext.User);
+            await store.ClearTokenAsync(httpContext.User, parameters);
         }
     }
 }

--- a/src/AccessTokenManagement/UserAccessAccessTokenManagementService.cs
+++ b/src/AccessTokenManagement/UserAccessAccessTokenManagementService.cs
@@ -118,7 +118,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
             CancellationToken cancellationToken = default)
         {
             parameters ??= new UserAccessTokenParameters();
-            var userToken = await _userTokenStore.GetTokenAsync(user);
+            var userToken = await _userTokenStore.GetTokenAsync(user, parameters);
 
             if (!string.IsNullOrEmpty(userToken?.RefreshToken))
             {
@@ -133,7 +133,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
 
         private async Task<TokenResponse> RefreshUserAccessTokenAsync(ClaimsPrincipal user, UserAccessTokenParameters parameters, CancellationToken cancellationToken = default)
         {
-            var userToken = await _userTokenStore.GetTokenAsync(user);
+            var userToken = await _userTokenStore.GetTokenAsync(user, parameters);
             var response = await _tokenEndpointService.RefreshUserAccessTokenAsync(userToken.RefreshToken, parameters, cancellationToken);
 
             if (!response.IsError)


### PR DESCRIPTION
**Problem:**

When using a different `DefaultScheme` and `DefaultChallengeScheme`, you can pass this in the `UserAccessTokenParameters`. However, the parameters are not always passed to the methods that rely on It, which results in an exception that cookies cannot be found. 

**Fix:** 

Pass along the `parameters` instance to all methods.