### PR TITLE
User access token handler

### DIFF
--- a/src/AccessTokenManagement/UserAccessToken/UserAccessTokenHandler.cs
+++ b/src/AccessTokenManagement/UserAccessToken/UserAccessTokenHandler.cs
@@ -26,7 +26,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement
         public UserAccessTokenHandler(IHttpContextAccessor httpContextAccessor, UserAccessTokenParameters parameters = null)
         {
             _httpContextAccessor = httpContextAccessor;
-            _parameters ??= new UserAccessTokenParameters();
+            _parameters = parameters ?? new UserAccessTokenParameters();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Fixed a small bug in the UserAccessTokenHandler where SignInScheme parameter is ignored and always uses DefaultScheme as a result.

Affecting applications using multiple authentication schemes.